### PR TITLE
fix: dispose TextEditingController with input

### DIFF
--- a/docs/glade-model.mdx
+++ b/docs/glade-model.mdx
@@ -122,5 +122,13 @@ class MyModel extends GladeModel {
 
 These metadata will be visible in `GladeFormDebugInfo` widget under model's section.
 
+## Disposing
+
+`GladeModel` is a `ChangeNotifier`, therefore it has to be disposed. When using `GladeFormBuilder.create()` or `GladeModelProvider()`, disposal is handled for you.
+
+`GladeModel.dispose()` disposes all inputs listed in `allInputs`. Each input disposes its `TextEditingController`, but only the one it created by itself. A controller provided through the `textEditingController` parameter is never disposed by the input - you are responsible for disposing it.
+
+<Warning>After the model is disposed, its inputs (and their controllers) must not be used anymore.</Warning>
+
 ----
 Looking for advanced behaviors such as controlling other inputs based on certain conditions? Check out the documentation for more information.

--- a/glade_forms/CHANGELOG.md
+++ b/glade_forms/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+- **[Fix]**: `GladeInput` now disposes its `TextEditingController` when the input is disposed ([#102](https://github.com/netglade/glade_forms/issues/102)).
+  - Externally provided controller (via `textEditingController` parameter) is **not** disposed - its owner stays responsible for it.
+  - Repeated `dispose()` calls are no-op. New `GladeInput.isDisposed` getter tells whether the input was already disposed.
+- **[Fix]**: `GladeModel.dispose()` now disposes all its inputs (`allInputs`).
+  - Be aware that after model's disposal its inputs (and their controllers) must not be used anymore.
+
 ## 6.0.1
 - **[Fix]**: `RegexPatterns.email` now accepts plus-aliases (e.g. `user+tag@gmail.com`) and TLDs longer than 4 characters (e.g. `.online`, `.software`). TLD is now restricted to letters only.
 

--- a/glade_forms/lib/src/core/input/glade_input.dart
+++ b/glade_forms/lib/src/core/input/glade_input.dart
@@ -61,6 +61,9 @@ class GladeInput<T> {
 
   final bool _useTextEditingController;
 
+  /// True when the controller was created by the input itself and therefore input is responsible for disposing it.
+  final bool _ownsTextEditingController;
+
   /// Initial value - does not change after creating.
   T? _initialValue;
 
@@ -80,6 +83,8 @@ class GladeInput<T> {
   /// If true onChange() is triggered.
   bool _controllerTriggersOnChange = true;
 
+  bool _isDisposed = false;
+
   /// Input is in invalid state when there was conversion error.
   ConvertError<T>? __conversionError;
 
@@ -92,6 +97,9 @@ class GladeInput<T> {
 
   /// Text editing controller for input. Used for syncing input with text field.
   TextEditingController? get controller => _textEditingController;
+
+  /// Input was already disposed and should not be used anymore.
+  bool get isDisposed => _isDisposed;
 
   T get value => _value;
 
@@ -182,7 +190,8 @@ class GladeInput<T> {
        _valueTransform = valueTransform,
 
        // ignore: avoid_bool_literals_in_conditional_expressions, cant be simplified.
-       _useTextEditingController = textEditingController != null ? true : useTextEditingController {
+       _useTextEditingController = textEditingController != null ? true : useTextEditingController,
+       _ownsTextEditingController = textEditingController == null && useTextEditingController {
     final defaultValue = (value ?? initialValue) as T;
     _textEditingController =
         textEditingController ??
@@ -522,9 +531,21 @@ class GladeInput<T> {
     );
   }
 
+  /// Releases input's resources.
+  ///
+  /// Disposes [controller] but only when it was created by the input itself.
+  /// Externally provided controller is left untouched and its owner is responsible for disposing it.
+  ///
+  /// Called automatically by `GladeModel.dispose()`. Repeated calls are no-op.
   @mustCallSuper
   void dispose() {
+    if (_isDisposed) return;
+
+    _isDisposed = true;
+
     _textEditingController?.removeListener(_onTextControllerChange);
+
+    if (_ownsTextEditingController) _textEditingController?.dispose();
   }
 
   @override

--- a/glade_forms/lib/src/model/glade_model.dart
+++ b/glade_forms/lib/src/model/glade_model.dart
@@ -176,4 +176,14 @@ abstract class GladeModel extends GladeModelBase {
   Map<String, Object> fillDebugMetadata() {
     return {};
   }
+
+  /// Disposes model and all its inputs (see [GladeInput.dispose]).
+  @override
+  void dispose() {
+    for (final input in allInputs) {
+      input.dispose();
+    }
+
+    super.dispose();
+  }
 }

--- a/glade_forms/test/dispose_test.dart
+++ b/glade_forms/test/dispose_test.dart
@@ -1,0 +1,84 @@
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter/widgets.dart';
+import 'package:glade_forms/glade_forms.dart';
+import 'package:test/test.dart';
+
+class _Model extends GladeModel {
+  late GladeStringInput name;
+  late GladeIntInput age;
+
+  @override
+  List<GladeInput<Object?>> get inputs => [name, age];
+
+  @override
+  void initialize() {
+    name = GladeStringInput(value: 'John', inputKey: 'name');
+    age = GladeIntInput(value: 20, inputKey: 'age');
+
+    super.initialize();
+  }
+}
+
+VoidCallback _assertNotDisposed(ChangeNotifier notifier) => () => ChangeNotifier.debugAssertNotDisposed(notifier);
+
+void main() {
+  setUp(GladeForms.initialize);
+
+  test('Input disposes controller which it created', () {
+    // arrange
+    final input = GladeStringInput(value: 'A');
+    final controller = input.controller!;
+
+    expect(_assertNotDisposed(controller), returnsNormally);
+
+    // act
+    input.dispose();
+
+    // assert
+    expect(input.isDisposed, isTrue);
+    expect(_assertNotDisposed(controller), throwsA(isA<FlutterError>()));
+  });
+
+  test('Input does not dispose externally provided controller', () {
+    // arrange
+    final controller = TextEditingController(text: 'A');
+    final input = GladeStringInput(value: 'A', textEditingController: controller);
+
+    // act
+    input.dispose();
+    controller.text = 'B';
+
+    // assert
+    expect(_assertNotDisposed(controller), returnsNormally);
+    expect(input.value, equals('A'), reason: 'Listener must be removed on dispose');
+
+    controller.dispose();
+  });
+
+  test('Repeated dispose is no-op', () {
+    // arrange
+    final input = GladeStringInput(value: 'A');
+
+    // act
+    input.dispose();
+
+    // assert
+    expect(input.dispose, returnsNormally);
+    expect(input.isDisposed, isTrue);
+  });
+
+  test('Model dispose disposes its inputs', () {
+    // arrange
+    final model = _Model();
+    final controller = model.name.controller!;
+
+    // act
+    model.dispose();
+
+    // assert
+    expect(model.name.isDisposed, isTrue);
+    expect(model.age.isDisposed, isTrue);
+    expect(_assertNotDisposed(controller), throwsA(isA<FlutterError>()));
+  });
+}


### PR DESCRIPTION
Closes #102

## Problem

`GladeInput.dispose()` only removed its listener from `TextEditingController` and never disposed it. On top of that, `GladeModel.dispose()` did not dispose its inputs at all, so `GladeInput.dispose()` was effectively never called - every model with a string input leaked a controller.

## Solution

- `GladeInput` tracks controller ownership. `dispose()` disposes the controller **only when the input created it** (`useTextEditingController: true` without a provided instance). A controller passed via `textEditingController` is left untouched - its owner stays responsible for it (this also covers `copyWith()`, where the copy receives the original's controller as external, so no double dispose).
- `dispose()` is idempotent and the new `GladeInput.isDisposed` getter exposes the state.
- `GladeModel.dispose()` disposes all inputs from `allInputs`.

## Behavior change

After a model is disposed, its inputs and their controllers must not be used anymore. Documented in `docs/glade-model.mdx`.

## Release

No version bump here - the CHANGELOG entry sits in the `## Unreleased` section. #105 turns it into the 6.1.0 release.

## Verification

- `flutter test` - all tests pass, incl. new `glade_forms/test/dispose_test.dart` (own vs. external controller, repeated dispose, model dispose)
- `dart analyze --fatal-infos` - no issues
- `dcm analyze lib test` - only the pre-existing `devtools_serialization.dart` extension-name warning