### PR TITLE
feat: allow silent attach of composed model's child

### DIFF
--- a/docs/advanced/composed-model.mdx
+++ b/docs/advanced/composed-model.mdx
@@ -33,6 +33,14 @@ composedModel.removeModel(model);
 
 Whenever any contained form model changes — or a model is added or removed — the entire composed form builder rebuilds to reflect the updated list.
 
+Sometimes a model has to be attached while the widget tree is building — e.g. a lazily built list creates a form model the first time a row asks for it. Notifying listeners during the build phase is not allowed by Flutter (`setState() or markNeedsBuild() called during build`), so use `shouldNotify: false` to attach the model silently:
+
+```dart
+composedModel.addModel(model, shouldNotify: false);
+```
+
+The newly attached model is fully registered — its own changes are propagated as usual, only the notification about the attachment itself is skipped. `removeModel()` accepts the same parameter.
+
 **Rendering multiple identical forms**
 
 Since all form models within a composed model share the same type, it's often helpful to automatically generate the same form widget for each model. This is where `GladeComposedListBuilder` comes in. It iterates through all models and builds the appropriate form widget for each one.

--- a/glade_forms/CHANGELOG.md
+++ b/glade_forms/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 6.1.0
+- **[Add]**: `GladeComposedModel.addModel()` and `removeModel()` accept `shouldNotify` parameter ([#104](https://github.com/netglade/glade_forms/issues/104)).
+  - Pass `shouldNotify: false` to attach or detach a model without notifying listeners - e.g. when a model is added during widget's build phase.
+  - Models passed into `GladeComposedModel`'s constructor no longer trigger notification.
+- **[Fix]**: `GladeInput` now disposes its `TextEditingController` when the input is disposed ([#102](https://github.com/netglade/glade_forms/issues/102)).
+  - Externally provided controller (via `textEditingController` parameter) is **not** disposed - its owner stays responsible for it.
+  - Repeated `dispose()` calls are no-op. New `GladeInput.isDisposed` getter tells whether the input was already disposed.
+- **[Fix]**: `GladeModel.dispose()` now disposes all its inputs (`allInputs`).
+  - Be aware that after model's disposal its inputs (and their controllers) must not be used anymore.
+
 ## 6.0.1
 - **[Fix]**: `RegexPatterns.email` now accepts plus-aliases (e.g. `user+tag@gmail.com`) and TLDs longer than 4 characters (e.g. `.online`, `.software`). TLD is now restricted to letters only.
 

--- a/glade_forms/lib/src/model/glade_composed_model.dart
+++ b/glade_forms/lib/src/model/glade_composed_model.dart
@@ -36,7 +36,7 @@ abstract class GladeComposedModel<M extends GladeModelBase> extends GladeModelBa
   GladeComposedModel([List<M>? initialModels]) {
     if (initialModels != null) {
       for (final model in initialModels) {
-        addModel(model);
+        addModel(model, shouldNotify: false);
       }
     }
     registerWithDevTools();
@@ -44,22 +44,29 @@ abstract class GladeComposedModel<M extends GladeModelBase> extends GladeModelBa
 
   /// Adds model to `models` list.
   /// Whenever form model changes, it triggers also change on this composed model.
-  void addModel(M model) {
+  ///
+  /// [shouldNotify] - if false, listeners are not notified about the attachment.
+  /// Use it when model is attached during widget's build phase where notifying listeners is not allowed.
+  void addModel(M model, {bool shouldNotify = true}) {
     _models.add(model);
     model
       ..addListener(notifyListeners)
       ..bindToComposedModel(this);
-    notifyListeners();
+
+    if (shouldNotify) notifyListeners();
   }
 
   /// Removes model from `models` list.
   /// Also unregisters from listening to its changes.
-  void removeModel(M model) {
+  ///
+  /// [shouldNotify] - if false, listeners are not notified about the detachment.
+  void removeModel(M model, {bool shouldNotify = true}) {
     final _ = _models.remove(model);
     model
       ..removeListener(notifyListeners)
       ..unbindFromComposedModel(this);
-    notifyListeners();
+
+    if (shouldNotify) notifyListeners();
   }
 
   @override

--- a/glade_forms/pubspec.yaml
+++ b/glade_forms/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glade_forms
 resolution: workspace
 description: A universal way to define form validators with support of translations.
-version: 6.0.1
+version: 6.1.0
 repository: https://github.com/netglade/glade_forms
 issue_tracker: https://github.com/netglade/glade_forms/issues
 

--- a/glade_forms/test/model/composed_model_test.dart
+++ b/glade_forms/test/model/composed_model_test.dart
@@ -1,0 +1,121 @@
+// ignore_for_file: cascade_invocations
+
+import 'package:glade_forms/glade_forms.dart';
+import 'package:test/test.dart';
+
+class _RowModel extends GladeModel {
+  late GladeStringInput name;
+
+  @override
+  List<GladeInput<Object?>> get inputs => [name];
+
+  @override
+  void initialize() {
+    name = GladeStringInput(value: '', inputKey: 'name');
+
+    super.initialize();
+  }
+}
+
+class _ComposedModel extends GladeComposedModel<_RowModel> {
+  _ComposedModel([super.initialModels]);
+}
+
+class _NotificationCounter {
+  int count = 0;
+
+  void increment() => count++;
+}
+
+void main() {
+  setUp(GladeForms.initialize);
+
+  test('addModel notifies listeners by default', () {
+    // arrange
+    final composed = _ComposedModel();
+    final counter = _NotificationCounter();
+    composed.addListener(counter.increment);
+
+    // act
+    composed.addModel(_RowModel());
+
+    // assert
+    expect(counter.count, equals(1));
+    expect(composed.models, hasLength(1));
+  });
+
+  test('addModel with shouldNotify false does not notify listeners', () {
+    // arrange
+    final composed = _ComposedModel();
+    final model = _RowModel();
+    final counter = _NotificationCounter();
+    composed.addListener(counter.increment);
+
+    // act
+    composed.addModel(model, shouldNotify: false);
+
+    // assert
+    expect(counter.count, isZero);
+    expect(composed.models, equals([model]));
+  });
+
+  test('Silently added model still propagates its changes', () {
+    // arrange
+    final composed = _ComposedModel();
+    final model = _RowModel();
+    final counter = _NotificationCounter();
+
+    composed.addModel(model, shouldNotify: false);
+    composed.addListener(counter.increment);
+
+    // act
+    model.name.value = 'John';
+
+    // assert
+    expect(counter.count, isNonZero);
+    expect(composed.isDirty, isTrue);
+  });
+
+  test('removeModel notifies listeners by default', () {
+    // arrange
+    final model = _RowModel();
+    final composed = _ComposedModel([model]);
+    final counter = _NotificationCounter();
+    composed.addListener(counter.increment);
+
+    // act
+    composed.removeModel(model);
+
+    // assert
+    expect(counter.count, equals(1));
+    expect(composed.models, isEmpty);
+  });
+
+  test('removeModel with shouldNotify false does not notify listeners', () {
+    // arrange
+    final model = _RowModel();
+    final composed = _ComposedModel([model]);
+    final counter = _NotificationCounter();
+    composed.addListener(counter.increment);
+
+    // act
+    composed.removeModel(model, shouldNotify: false);
+    model.name.value = 'John';
+
+    // assert
+    expect(counter.count, isZero);
+    expect(composed.models, isEmpty);
+  });
+
+  test('Models passed to constructor are registered', () {
+    // arrange
+    final model = _RowModel();
+
+    // act
+    final composed = _ComposedModel([model]);
+
+    // assert
+    expect(composed.models, equals([model]));
+    expect(composed.isPure, isTrue);
+  });
+}


### PR DESCRIPTION
Closes #104

## Problem

`GladeComposedModel.addModel()` called `notifyListeners()` unconditionally, so a child model could not be attached while the widget tree is building — Flutter throws `setState() or markNeedsBuild() called during build`. That blocks the lazily built list scenario, where a row creates its form model the first time it is asked for, even though a pristine child changes nothing observable on the parent.

## Solution

`addModel()` and `removeModel()` take a `shouldNotify` parameter (default `true`, so nothing changes for existing callers):

```dart
composedModel.addModel(model, shouldNotify: false);
```

The model is fully registered either way — its own changes propagate as usual, only the notification about the attach/detach itself is skipped.

Models passed into `GladeComposedModel`'s constructor are now attached with `shouldNotify: false`, since no listener can be subscribed at that point anyway.

The parameter is named `shouldNotify` rather than `notify` from the issue, to match the existing naming in the package (`shouldTriggerOnChange`, `shouldResetToInitialValue`).

## Release

This is the release PR for **6.1.0** — it bumps `pubspec.yaml` and its CHANGELOG section covers both this change and the disposal fix from #103.

Merge order: #103 first (its entry sits in `## Unreleased`), then `main` gets merged in here and the `## Unreleased` heading is dropped in favor of the `## 6.1.0` section already prepared in this branch.

## Verification

- `flutter test` — all tests pass, incl. new `glade_forms/test/model/composed_model_test.dart` (default notify, silent attach/detach, propagation of a silently attached model's changes, constructor registration)
- `dart analyze --fatal-infos` — no issues
- `dcm analyze lib test` — only the pre-existing `devtools_serialization.dart` extension-name warning