### PR TITLE
fix: repair GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -36,15 +36,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure FVM
-        uses: kuhnroyal/flutter-fvm-config-action@v1
-        with:
-          path: ".fvm/fvm_config.json"
+        uses: kuhnroyal/flutter-fvm-config-action@v2
+        id: fvm-config-action
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
       - uses: bluefireteam/melos-action@v3
 
@@ -60,11 +59,11 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: "storybook/build/web/"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The 6.1.0 merge did not publish the storybook — but the merge is not the cause. Every "Deploy static content to Pages" run has failed the same way for months (latest: [run 34446554649](https://github.com/netglade/glade_forms/actions/runs/34446554649), same failure back in [run 19966003334](https://github.com/netglade/glade_forms/actions/runs/19966003334) from December).

## Cause

The job is rejected before a single step runs:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`

`actions/upload-pages-artifact@v2` depends on `upload-artifact@v3`, which GitHub hard-fails since the [v3 deprecation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

Second problem waiting behind it: the FVM step read `path: ".fvm/fvm_config.json"`, but that file is not in the repository — only `.fvmrc` is — so `env.FLUTTER_VERSION` would resolve to an empty value.

## Fix

- `actions/upload-pages-artifact@v2` → `@v3`, `actions/deploy-pages@v2` → `@v4`
- FVM step switched to `kuhnroyal/flutter-fvm-config-action@v2` with step outputs, matching the working setup in `ci.yaml`

## Verification

The workflow only runs on push to `main`, so it can be confirmed for real only after merge. What was checked locally with the repo's Flutter (3.38.7):

- both `easy_localization:generate` steps — generated successfully
- `flutter build web --base-href "/glade_forms/"` in `storybook/` — `✓ Built build/web`
- Pages settings are already on `build_type: workflow`, so `deploy-pages` has a valid target

Note: the local build initially failed on `accessibility_tools 2.7.1` being incompatible with the current Flutter `SemanticsFlags` API. That was a stale local lockfile only — `pubspec.lock` is gitignored, so CI resolves `2.8.0` and compiles fine. Nothing to commit for it.